### PR TITLE
CMake corrections and updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,22 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.16.3)
 
-set( CMAKE_VERBOSE_MAKEFILE ON )
+if(NOT DEFINED STAGGERED_DEBUG AND DEFINED ENV{STAGGERED_DEBUG})
+  set(STAGGERED_DEBUG $ENV{STAGGERED_DEBUG})
+endif()
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+  if(STAGGERED_DEBUG)
+      set(CMAKE_BUILD_TYPE "Debug" STRING CACHE "Debug")
+    else()
+      set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release default")
+    endif()
+endif()
 
-
-set (CMAKE_CXX_STANDARD 11)
-
-project(BabelViscoFDTD LANGUAGES C CXX)
+project(BabelViscoFDTD LANGUAGES C)
 
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
+set( CMAKE_VERBOSE_MAKEFILE ON )
+set (CMAKE_C_STANDARD 11)
 
 option(STAGGERED_OPT "Enable platform-specific optimisations" ON)
 option(STAGGERED_VERBOSE "Enable verbose output" ON)
@@ -17,7 +25,5 @@ option(STAGGERED_FAST_MATH "Enable unsafe optimisations (non IEEE 754 compliant)
 option(STAGGERED_OMP_SUPPORT "Build with OpenMP support" ON)
 option(STAGGERED_CUDA_SUPPORT "Build with CUDA support" ON)
 option(STAGGERED_PYTHON_SUPPORT "Build Python C extension module" ON)
-
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,20 @@ endif()
 
 project(BabelViscoFDTD LANGUAGES C)
 
+if(CMAKE_GENERATOR MATCHES "Ninja")
+  enable_language(Swift)
+else()
+  message(STATUS "To enable Metal Swift targets, use the CMake Ninja generator, e.g.
+
+  cmake -G Ninja -B ${PROJECT_BINARY_DIR}
+  ")
+endif()
+
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 set( CMAKE_VERBOSE_MAKEFILE ON )
-set (CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
 
 option(STAGGERED_OPT "Enable platform-specific optimisations" ON)
 option(STAGGERED_VERBOSE "Enable verbose output" ON)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 BabelViscoFDTD
 =============
-Samuel Pichardo, Ph.D  
-Associate Professor  
-Radiology and Clinical Neurosciences, Hotchkiss Brain Institute  
-Cumming School of Medicine,  
-University of Calgary   
-samuel.pichardo@ucalgary.ca  
+Samuel Pichardo, Ph.D
+Associate Professor
+Radiology and Clinical Neurosciences, Hotchkiss Brain Institute
+Cumming School of Medicine,
+University of Calgary
+samuel.pichardo@ucalgary.ca
 www.neurofus.ca
 
 **Software library for FDTD of the viscoelastic equation using a staggered grid arrangement and including the superposition method, with multiple CPU- and GPU-based backends (OpenMP, CUDA, OpenCL and Metal)**
@@ -48,7 +48,7 @@ The use of virtual environments is recommended. Anaconda Python and Enthought ED
 The code has been verified to work from CUDA 9 to CUDA 11. Highly likely older versions of CUDA (7, 8) should work without a problem. Be sure of installing the CUDA samples and take note of the location where they were installed.
 
 ## CMAKE
-CMAKE version>= 3.16.3. 
+CMAKE version>= 3.16.3.
 
 ## OpenCL
 OpenCL for Windows and Apple Silicon systems is operational via `pyopencl`. In macOS, you can install pyopencl with `pip install pyopencl`. In Windows, use one of the precompiled wheels in https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl. The FDTD kernels code is OpenCL >= 1.2 compliant.
@@ -62,7 +62,7 @@ latest version of `pip`
 * pydicom>=1.3.0
 * setuptools >=51.0.0
 * pyopencl>=2020 (if in Windows, install manually a wheel from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl)
-* cupy-cuda11x in Linux (via pip). In Windows install with conda in windows with `conda install -c conda-forge cupy` 
+* cupy-cuda11x in Linux (via pip). In Windows install with conda in windows with `conda install -c conda-forge cupy`
 
 `h5py`, `hdf5plugin`, `pydicom` and `pyopencl` are installed automatically as requirements if they are no present in the Python enviroment..
 
@@ -111,7 +111,7 @@ You may also need to install OpenCL headers and libraries such as `opencl-header
 #### Linux in Windows through WSL2
 Starting in 2020, support for CUDA execution directly in WSL2 became possible. We have had excellent experiences with it. Just follow the official instructions from NVIDIA (https://docs.nvidia.com/cuda/wsl-user-guide/index.html)
 
-Please note that OpenCL is not supported under WSL2. 
+Please note that OpenCL is not supported under WSL2.
 
 ### Windows native
 You will need a VStudio installation that is compatible with your CUDA version; for example, CUDA 11.2 supports officially VS 2015 to 2019.
@@ -119,7 +119,7 @@ You will need a VStudio installation that is compatible with your CUDA version; 
 ### macOS
 Any recent version of macOS and XCode with the command-line tools should be enough. Most tests have been done in Big Slur and Monterey. The CPU version in macOS supports OpenMP in ARM64 processors (M1, M1 Max, M2 ultra, M2). In X86-64, the OpenMP feature is now turned as experimental; by default, it will run only single-thread. See below for details on how to enable it. For ARM64 version will have OpenMP fully enabled by default.
 
-The OpenCL and Metal backed have been tested in Intel-based integrated GPUs, AMD GPUs and  ARM64-based systems. There are, however, some limitations of AMD GPUs with OpenCL (see below macOS notes for more details). Metal backend is available for both X86-64 and Apple Silicon systems. Overall, Metal is the recommended backend for M1 processors and AMD GPUs. 
+The OpenCL and Metal backed have been tested in Intel-based integrated GPUs, AMD GPUs and  ARM64-based systems. There are, however, some limitations of AMD GPUs with OpenCL (see below macOS notes for more details). Metal backend is available for both X86-64 and Apple Silicon systems. Overall, Metal is the recommended backend for M1 processors and AMD GPUs.
 
 Best scenario for both X64 and ARM64-based systems is to use fully native Python distributions using homebrew:
 1. Install  [homebrew](https://brew.sh/)
@@ -133,10 +133,18 @@ Best scenario for both X64 and ARM64-based systems is to use fully native Python
 `pip install BabelViscoFDTD`
 
 #### macOS experimental OpenMP in X86-64
+
 Thanks to the people who have reported the mitigated success with OpenMP. In my current systems, I didn't have problems, but later some users reported having issues with OpenMP. Then, we turned this feature as **experimental**, the time we can figure out a more stable approach.
-For X86-64, `libomp` and `mkl` must be installed first, otherwise compilation and execution for OpenMP will fail.
-* Install `libomp` with `brew install libomp`  
-* Install `mkl` with `pip install mkl` or `conda install mkl`
+For Intel or Apple Silicon CPU, `libomp` and `mkl` must be installed first, otherwise compilation and execution for OpenMP will fail.
+Install `mkl` with `pip install mkl` or `conda install mkl`
+
+Using Homebrew, install OpenMP and hint location to CMake:
+
+```sh
+brew install libomp
+
+export OpenMP_ROOT=/opt/homebrew/opt/libomp
+```
 
 
 To enable the OpenMP version for macOS install BabelViscoFDTD with:
@@ -169,10 +177,10 @@ Regardless if using CUDA, OpenCL or Metal, conceptually the workflow is very sim
 
 # Important information specific to the different environments for use
 ### macOS notes
-macOS support for HPC has shifted in recent years significantly. In modern macOS versions, the support for NVIDIA cards is inexistent and OpenCL *was supposed to be* officially out of support beyond Big Slur (*it is still running quite well in Monterey*). For macOS, Metal backend is recommended for AMD processors. OpenCL in macOS X86_64 may have other limitations such as the underlying driver may only support 32 bits memory access, even if the card has more than 4 GB of RAM. However, this limitation seems to be case by case. For ARM64 processors, OpenCL drivers can support 64 bit addressing. For an AMD W6800 (32 GB RAM) it only supports 32 bits. The `clinfo` tool (available with homebrew) can provide details if your current GPU and drivers support 64 bits addressing. The OpenCL implementation with ARM64 processors works only with a native Python arm64 installation. 
+macOS support for HPC has shifted in recent years significantly. In modern macOS versions, the support for NVIDIA cards is inexistent and OpenCL *was supposed to be* officially out of support beyond Big Slur (*it is still running quite well in Monterey*). For macOS, Metal backend is recommended for AMD processors. OpenCL in macOS X86_64 may have other limitations such as the underlying driver may only support 32 bits memory access, even if the card has more than 4 GB of RAM. However, this limitation seems to be case by case. For ARM64 processors, OpenCL drivers can support 64 bit addressing. For an AMD W6800 (32 GB RAM) it only supports 32 bits. The `clinfo` tool (available with homebrew) can provide details if your current GPU and drivers support 64 bits addressing. The OpenCL implementation with ARM64 processors works only with a native Python arm64 installation.
 
 ### Metal support
-Overall, Metal requires a bit more coding to prepare the pipelines for compute execution.  A challenge is that Metal for scientific computing still lacks serious examples. Nevertheless, the support for Metal is desirable for Apple Silicon systems. As toolchains, including native Python in arm64, are now becoming widespread available, it is interesting to see how well these devices stand quite well compared to Nvidia or AMD-based systems. There are some limitations such as the maximal number of kernel parameters (32) and that each GPU buffer memory is limited to 3.5 GB RAM for Metal-supported GPUs. But this is a limitation manageable by packing multiple logical arrays across multiple buffers. We explored the use of Metal Argument Buffers, but it ended in poorer performance than packing multiple arrays logically. In the current release of BabelViscoFDTD, it is completely stable to run large domains with AMD GPUs and ARM64-based processors with 32 or more GB of RAM. 
+Overall, Metal requires a bit more coding to prepare the pipelines for compute execution.  A challenge is that Metal for scientific computing still lacks serious examples. Nevertheless, the support for Metal is desirable for Apple Silicon systems. As toolchains, including native Python in arm64, are now becoming widespread available, it is interesting to see how well these devices stand quite well compared to Nvidia or AMD-based systems. There are some limitations such as the maximal number of kernel parameters (32) and that each GPU buffer memory is limited to 3.5 GB RAM for Metal-supported GPUs. But this is a limitation manageable by packing multiple logical arrays across multiple buffers. We explored the use of Metal Argument Buffers, but it ended in poorer performance than packing multiple arrays logically. In the current release of BabelViscoFDTD, it is completely stable to run large domains with AMD GPUs and ARM64-based processors with 32 or more GB of RAM.
 
 While Metal offers better performance overall over OpenCL in both Apple and AMD processors, some issues remain. Extensive testing has indicated that the Python process freezes after running a few tens of thousands of kernel calls. For most of the applications, this won't be an issue. If running very long extensive parametric studies under a single execution, be aware you may need to split your execution into chunks that can be called in separate `python <Myprogram.py>` calls. I suspect some driver issue limiting the number of consecutive kernels calls in a single process.
 
@@ -180,11 +188,11 @@ While Metal offers better performance overall over OpenCL in both Apple and AMD 
 Performance between modern AMD, NVIDIA and Apple Silicon GPUs can show important differences. A simulation for a domain of  [414, 219 , 375] grid size and over 2841 temporal steps was used to benchmark multiple backends and systems.
 
 * Nvidia RTX A6000 (48 GB RAM, 10752 CUDA Cores, theoretical 38.7 SP TFLOP , memory bandwidth 768 GB/s)
-* AMD Radeon Pro W6800 (32 GB RAM, 3840  stream processors, theoretical 17.83 SP TFLOP, memory bandwidth 512 GB/s) 
-* AMD Vega 56 (8 GB RAM, 3584  stream processors, theoretical 10.5 SP TFLOP, memory bandwidth  410 GB/s) 
+* AMD Radeon Pro W6800 (32 GB RAM, 3840  stream processors, theoretical 17.83 SP TFLOP, memory bandwidth 512 GB/s)
+* AMD Vega 56 (8 GB RAM, 3584  stream processors, theoretical 10.5 SP TFLOP, memory bandwidth  410 GB/s)
 * M1 Max  (64 GB RAM, 10 CPU cores, 32 GPU Cores, 4096 execution units (which PR material says translates into a theoretical 98304 simultaneous threads), theoretical 10.4 SP TFLOP, memory bandwidth 400 GB/s)
 
-RTX A6000 test was done in 128 GB Xeon W-2125 CPU (4x2 cores) @ 4.00GHz Dell system. AMD Vega 64 and AMD Radeon Pro W6800 were tested in an 128 GB iMac Pro system (10x2 Core Intel Xeon W). The Vega 64 GPU is part of the iMac system, while the Pro W6800 is connected via a Thunderbolt 3 external enclosure. Please note that GPU connectivity should not have an important effect given memory transfers between GPU and CPU are minimal. The M1 Max was configured with 64 GB and installed in a 2021 MacBook Pro system. The Dell system, iMac Pro and MacBook Pro were also used for OpenMP benchmarks. Python 3.9 was used in all systems. The Dell system test used CUDA 11.4 and Visual Studio 2019 Community edition. The latest versions of pycuda and pyopencl at the time of testing (Sep 18, 2022) were used. macOS Monterey 12.5.1 with XCode 14 were used for both iMac Pro and MacBook Pro. 
+RTX A6000 test was done in 128 GB Xeon W-2125 CPU (4x2 cores) @ 4.00GHz Dell system. AMD Vega 64 and AMD Radeon Pro W6800 were tested in an 128 GB iMac Pro system (10x2 Core Intel Xeon W). The Vega 64 GPU is part of the iMac system, while the Pro W6800 is connected via a Thunderbolt 3 external enclosure. Please note that GPU connectivity should not have an important effect given memory transfers between GPU and CPU are minimal. The M1 Max was configured with 64 GB and installed in a 2021 MacBook Pro system. The Dell system, iMac Pro and MacBook Pro were also used for OpenMP benchmarks. Python 3.9 was used in all systems. The Dell system test used CUDA 11.4 and Visual Studio 2019 Community edition. The latest versions of pycuda and pyopencl at the time of testing (Sep 18, 2022) were used. macOS Monterey 12.5.1 with XCode 14 were used for both iMac Pro and MacBook Pro.
 
 Wall-time was measured from the moment preparations to run GPU code started (initiate device operation) to the end of the memory transfer of results, with no access to the main drives involved. Memory transfer between CPU and GPU occurred only at the beginning and end of GPU execution. The numerical difference among different backends was in the order of single precision resolution.
 
@@ -201,27 +209,27 @@ Wall-time was measured from the moment preparations to run GPU code started (ini
 #### Discussion of results
 The number of computing units is becoming a bit useless to compare. There are a few interesting aspects worth mentioning:
 * The ratio of performance between M1 Max and A6000 (CUDA vs. Metal) is not even close to the theoretical difference of raw SP TFLOPS%.
-* Metal and OpenCL performances of the M1 Max are pretty much equal, outmatching the A6000 performance. 
+* Metal and OpenCL performances of the M1 Max are pretty much equal, outmatching the A6000 performance.
 * Multiple tryouts on the CUDA code to adjust grid and block sizes didn't improve performance in the A6000. On the contrary, wall-time was increased, indicating that the recommended method by Nvidia to calculate maximal occupancy used by default in BabelViscoFDTD provided the best performance with the A6000.
-* The other surprise was the W6800 with Metal and OpenCL outperforming by a significant margin the A6000. 
-* The OpenMP performance of the M1 Max is also excellent, showing a dramatic speedup compared to the Dell Xeon and iMac Pro systems. 
+* The other surprise was the W6800 with Metal and OpenCL outperforming by a significant margin the A6000.
+* The OpenMP performance of the M1 Max is also excellent, showing a dramatic speedup compared to the Dell Xeon and iMac Pro systems.
 
 ## Possibility of manual adjustments to improve performance
-All three GPU backends have analogous control to split the calculations in the GPU multiprocessors. BabelViscoFDTD uses the methods that are recommended for each backend to ensure maximal GPU occupancy. However, manual adjustments can provide improvement to the performance. You can specify manually the grid and thread block dimensions with the optional parameters `ManualGroupSize` and `ManualLocalSize`, respectively. Please consult the guidelines of each backend (CUDA, OpenCL and Metal) on how to calculate this correctly, otherwise there is a risk of specifying a too large or too short grid and thread size dimensions. For example, for both CUDA and Metal, the multiplication of `ManualGroupSize` and `ManualLocalSize` must be equal or larger than the domain size ([N1,N2,N3]) to ensure all the domain is covered; for example for a domain of size [231,220,450], `ManualGroupSize=[60,60,115]` with `ManualLocalSize=[4,4,4]` will ensure covering the domain size. For `OpenCL` each entry in `ManualGroupSize` must be equal or larger than [N1,N2,N3] and each entry must be a multiple of its corresponding entry in `ManualLocalSize`; for example for a domain of size [231,220,450], `ManualGroupSize=[240,240,460]` with `ManualLocalSize=[4,4,4]`. Be sure of specifying these parameters as an np.array of type np.int32, such as `ManualLocalSize=np.array([4,4,4]).astype(np.int32)`. 
+All three GPU backends have analogous control to split the calculations in the GPU multiprocessors. BabelViscoFDTD uses the methods that are recommended for each backend to ensure maximal GPU occupancy. However, manual adjustments can provide improvement to the performance. You can specify manually the grid and thread block dimensions with the optional parameters `ManualGroupSize` and `ManualLocalSize`, respectively. Please consult the guidelines of each backend (CUDA, OpenCL and Metal) on how to calculate this correctly, otherwise there is a risk of specifying a too large or too short grid and thread size dimensions. For example, for both CUDA and Metal, the multiplication of `ManualGroupSize` and `ManualLocalSize` must be equal or larger than the domain size ([N1,N2,N3]) to ensure all the domain is covered; for example for a domain of size [231,220,450], `ManualGroupSize=[60,60,115]` with `ManualLocalSize=[4,4,4]` will ensure covering the domain size. For `OpenCL` each entry in `ManualGroupSize` must be equal or larger than [N1,N2,N3] and each entry must be a multiple of its corresponding entry in `ManualLocalSize`; for example for a domain of size [231,220,450], `ManualGroupSize=[240,240,460]` with `ManualLocalSize=[4,4,4]`. Be sure of specifying these parameters as an np.array of type np.int32, such as `ManualLocalSize=np.array([4,4,4]).astype(np.int32)`.
 
 # Supported platforms for Rayleigh's integral
-Since v0.9.2 Rayleigh-Sommerfeld's integral was added as a tool (see tutorial `Tutorial Notebooks\Tools -1 - Rayleigh Integral.ipynb`). This will be useful to combine models that include large volumes of water as the Rayleigh integral benefits considerably a GPU as the Rayleigh-Sommerfeld integral is hyper-parallel. The tool has support for 3 GPU backends: CUDA and OpenCL for Windows and Linux, and Metal and OpenCL for macOS. 
+Since v0.9.2 Rayleigh-Sommerfeld's integral was added as a tool (see tutorial `Tutorial Notebooks\Tools -1 - Rayleigh Integral.ipynb`). This will be useful to combine models that include large volumes of water as the Rayleigh integral benefits considerably a GPU as the Rayleigh-Sommerfeld integral is hyper-parallel. The tool has support for 3 GPU backends: CUDA and OpenCL for Windows and Linux, and Metal and OpenCL for macOS.
 
 # Release notes
-* 1.0.0 - That is it! After thousands of simulations for a manuscript preparation to introduce the [BabelBrain](https://github.com/ProteusMRIgHIFU/BabelBrain) planning suite (soon to become public), this is ready for an official 1.0.0 release. 
+* 1.0.0 - That is it! After thousands of simulations for a manuscript preparation to introduce the [BabelBrain](https://github.com/ProteusMRIgHIFU/BabelBrain) planning suite (soon to become public), this is ready for an official 1.0.0 release.
     * cupy replaces PyCUDA for all CUDA operations. PyCUDA needs a Visual Studio compiler on the path to compile kernels in Windows. BabelBrain uses a lot cupy; switching to it helps to keep using a single interface while benefitting from the availability of Numpy-like methods.
     * Add a new correction parameter for attenuation. One of the findings while preparing the use with BabelBrain was that mapping procedures in the literature linking CT Hounsfield Units (HU) to the speed of sound and, especially, attenuation needs this sort of correction.
 * 0.9.10-1 Nov 16, 2022
-    * Add functions to list devices supported by computing backends 
+    * Add functions to list devices supported by computing backends
 * 0.9.10 Oct 28, 2022
     * Fix the issue with mapping of unique values when attenuation is used, it could cause some divisions by zero
 * 0.9.9.20 Sep 17, 2022
-    * A lot of important improvements to make the final line  
+    * A lot of important improvements to make the final line
         - Metal is (finally) running as fast (sometimes slightly faster) than OpenCL in Apple processors. It took a lot of testing and fine tuning.
         - Use of a modified version of the excellent `py-metal-compute` library (https://github.com/baldand/py-metal-compute) that allows having a similar approach as with pyopencl, cupy and pycuda. Modified library is at https://github.com/ProteusMRIgHIFU/py-metal-compute. Because of this new approach, the old Swift interface to the FDTD code was removed.
         - Add Metal backend for BHTE tool. This version runs way faster than OpenCL in Apple processors (like a 10x factor, need to investigate more if we can replicate such gain)
@@ -229,9 +237,9 @@ Since v0.9.2 Rayleigh-Sommerfeld's integral was added as a tool (see tutorial `T
         - Moving forward, OpenCL is not recommended for macOS in X64 systems. Because of the limitation of the underlying 32-bit addressing, pyopencl does not catch easily when a simulation goes beyond 4GB. However, Metal for AMD in macOS runs quite well, so no need to stick with OpenCL
 
 * 0.9.9  Sep 1, 2022
-    * A lot of simplifications allowed having a much more straightforward code. Thanks to Andrew Xie (@IAmAndrewX) for a very productive summer trimming down code, replacing the old MTLPP with Swift, and making a new class arrangement for the different GPU backends. Now BabelViscoFDTD is based completely on pyopencl and pycuda for the FDTD viscoelastic solver. For Metal, the Swift-based wrapper does the interfacing. The old C extension is still around just for the OpenMP backend.  
+    * A lot of simplifications allowed having a much more straightforward code. Thanks to Andrew Xie (@IAmAndrewX) for a very productive summer trimming down code, replacing the old MTLPP with Swift, and making a new class arrangement for the different GPU backends. Now BabelViscoFDTD is based completely on pyopencl and pycuda for the FDTD viscoelastic solver. For Metal, the Swift-based wrapper does the interfacing. The old C extension is still around just for the OpenMP backend.
 * 0.9.7  July 7, 2022
-    * The MTLPP C++ library is now replaced by a Swift interface to access the Metal implementation for the viscoelastic FDTD solution. This will ensure using a more standard Apple development language for the future, as MTLPP is not maintained anymore. While there is a new Apple-based C++ wrapper for Metal, using Swift is still preferred as we created now a C-linking compatible library that in the future can be also used directly in Python. In the long term, we aim to eliminate the C code extension and use only Python code in tandem with pyopencl, pycuda and  Metal 
+    * The MTLPP C++ library is now replaced by a Swift interface to access the Metal implementation for the viscoelastic FDTD solution. This will ensure using a more standard Apple development language for the future, as MTLPP is not maintained anymore. While there is a new Apple-based C++ wrapper for Metal, using Swift is still preferred as we created now a C-linking compatible library that in the future can be also used directly in Python. In the long term, we aim to eliminate the C code extension and use only Python code in tandem with pyopencl, pycuda and  Metal
 * 0.9.6-post-10  June 27, 2022
     * A fix for OpenCL in X64 Mac system that was missing the new kernel names
     * OpenMP for X64 in Mac is being turned back as experimental feature as some systems are unable to run with it correctly and there is not a clear path on how to ensure this will be stable. The feature will remain accessible if installing the library with the BABEL_MAC_OPENMP_X64 option enabled.
@@ -242,7 +250,7 @@ Since v0.9.2 Rayleigh-Sommerfeld's integral was added as a tool (see tutorial `T
     * Very first pip-registered version
     * Possibility of user-specified dimensions of blocks for computations for fine-tuning performance
     * Cleaning some minor bugs and adding BHTE code using pycuda and pyopencl.
-    
+
 * 0.9.3  Sep 29, 2021.
     * Improved support for both Metal and OpenCL. For Metal, stable operation is now feasible for large domains using all available memory in modern high-end GPUs. OpenCL is now supported in all OSs.
 * 0.9.2  June 13, 2021.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def CompileBabelMetal(build_temp,build_lib):
     global extra_obj
     if not bBabelMetalCompiled:
         print('Compiling Metal')
-        ## There are no easy rules yet in CMAKE to do this through CMakeFiles, but 
+        ## There are no easy rules yet in CMAKE to do this through CMakeFiles, but
         ## since the compilation is very simple, we can do this manually
         print('Compiling Metal interface')
         copytree(dir_path+'src/Metal',build_temp )
@@ -69,11 +69,11 @@ def PrepareOpenCLKernel():
                     inclines=g.readlines()
                 f.writelines(inclines)
     copyfile(dir_path+'src'+os.sep+'Indexing.h',dir_path+'BabelViscoFDTD'+os.sep+'_indexing.h')
-    
-install_requires=['numpy', 
-                'scipy', 
+
+install_requires=['numpy',
+                'scipy',
                 'h5py',
-                'hdf5plugin', 
+                'hdf5plugin',
                 'pydicom',
                 'pyopencl']
 
@@ -103,7 +103,7 @@ if 'Darwin' not in platform.system():
 
     class CMakeBuild(build_ext):
         def build_extensions(self):
-    
+
             try:
                 out = subprocess.check_output(['cmake', '--version'])
             except OSError:
@@ -111,16 +111,16 @@ if 'Darwin' not in platform.system():
 
             if platform.system() in ['Darwin']:
                 CompileBabelMetal(self.build_temp,self.build_lib)
-                ## There are no easy rules yet in CMAKE to do this through CMakeFiles, but 
+                ## There are no easy rules yet in CMAKE to do this through CMakeFiles, but
                 ## since the compilation is very simple, we can do this manually
-                
+
 
             for ext in self.extensions:
                 print('ext',ext.name)
                 extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
                 cfg = 'Debug' if _get_env_variable('STAGGERED_DEBUG') == 'ON' else 'Release'
                 cmake_args =[
-                    '-DSTAGGERED_DEBUG=%s' % ('ON' if cfg == 'Debug' else 'OFF'),
+                    '-DCMAKE_BUILD_TYPE=%s' % ('Debug' if cfg == 'Debug' else 'Release'),
                     '-DSTAGGERED_OPT=%s' % _get_env_variable('STAGGERED_OPT'),
                     '-DSTAGGERED_SINGLE=%s' % ('ON' if 'single' in ext.name else 'OFF'),
                     '-DSTAGGERED_OMP_SUPPORT=%s' % ('OFF' if ('OPENCL' in ext.name or platform.system()=='Darwin' ) else 'ON'),
@@ -174,7 +174,7 @@ if 'Darwin' not in platform.system():
                 CMakeExtension(c_module_name+'_double')]
 
     cmdclass= {'build_ext': CMakeBuild}
-   
+
 
 else:
     #specific building conditions for Apple  systems
@@ -243,7 +243,7 @@ else:
             print('building extension')
             CompileBabelMetal(self.build_temp,self.build_lib)
             super().build_extensions()
-            
+
 
     from mmap import PAGESIZE
     bIncludePagememory=np.__version__ >="1.22.0"
@@ -253,7 +253,7 @@ else:
         extra_link_args_omp=['-lomp']
         define_macros_omp=[("USE_OPENMP",None)]
     else:
-        OPENMP_X64 = os.getenv('BABEL_MAC_OPENMP_X64') 
+        OPENMP_X64 = os.getenv('BABEL_MAC_OPENMP_X64')
         print('BABEL_MAC_OPENMP_X64',OPENMP_X64)
         bUseOpenMP=True
         if OPENMP_X64 is not None:
@@ -270,28 +270,28 @@ else:
             extra_link_args_omp=[]
             define_macros_omp=[]
 
-    ext_modules=[Extension(c_module_name+'_single', 
+    ext_modules=[Extension(c_module_name+'_single',
                     ["src/FDTDStaggered3D_with_relaxation_python.c"],
                     define_macros=[("SINGLE_PREC",None)]+define_macros_omp,
                     extra_compile_args=extra_compile_args_omp,
                     extra_link_args=extra_link_args_omp,
                     include_dirs=[npinc]),
-                Extension(c_module_name+'_double', 
+                Extension(c_module_name+'_double',
                     ["src/FDTDStaggered3D_with_relaxation_python.c"],
                     define_macros=define_macros_omp,
                     extra_compile_args=extra_compile_args_omp,
                     extra_link_args=extra_link_args_omp,
                     include_dirs=[npinc])]
-                    
-    
+
+
 
     if bIncludePagememory:
-        ext_modules.append(Extension('BabelViscoFDTD.tools._page_memory', 
+        ext_modules.append(Extension('BabelViscoFDTD.tools._page_memory',
                             ["src/page_memory.c"],
                             define_macros=[("PAGE_SIZE",str(PAGESIZE))],
                             include_dirs=[npinc]))
     cmdclass = {'build_ext':DarwinInteropBuildExt}#, 'install':PostInstallCommand}
-    
+
 
 setup(name="BabelViscoFDTD",
         version=version,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,137 +5,100 @@ set(STAGGERED_PYTHON_C_MODULE_NAME  CACHE STRING "Name of the C extension module
 
 # Find OpenMP if required
 if(STAGGERED_OMP_SUPPORT)
-      find_package(OpenMP REQUIRED)
-      if(OPENMP_FOUND)
-          set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -DUSE_OPENMP")
-          set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-      endif()
-else()
-    if(NOT MSVC)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")
-    endif()
-endif()
-
-# Enable debug if required
-if(STAGGERED_DEBUG)
-    if(MSVC)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Zi")
-    else()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g")
-    endif()
-else()
-    if(MSVC)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox")
-    else()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
-    endif()
+  find_package(OpenMP COMPONENTS C REQUIRED)
+  if(OpenMP_C_FOUND)
+    add_compile_definitions(USE_OPENMP)
+  endif()
+elseif(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wno-unknown-pragmas>)
 endif()
 
 # Enable non-portable optimisations if required
 if(STAGGERED_OPT AND NOT STAGGERED_DEBUG)
-    if(NOT MSVC)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
-    endif()
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-march=native>)
+  endif()
 endif()
 
 # Enable unsafe optimisations if required
 if(STAGGERED_FAST_MATH AND NOT STAGGERED_DEBUG)
-    if(MSVC)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fp:fast")
-    else()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffast-math")
-    endif()
+  if(MSVC)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:/fp:fast>)
+  elseif(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-ffast-math>)
+  endif()
 endif()
 
 
 # Use double precision if required
 if(STAGGERED_SINGLE)
-    add_definitions(-DSINGLE_PREC)
+  add_compile_definitions(SINGLE_PREC)
 endif()
 
 # Set some compiler flags
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W0")
-else()
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:/W0>)
+elseif(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+  add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wall;-Wextra>")
 endif()
 
-# Add Python component if requested
+# ------------- Project targets -------------
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+
+endif()
+
+
+# --- Python C extension ---
 if(STAGGERED_PYTHON_SUPPORT)
-    set(Python_FIND_VIRTUALENV FIRST)
-    find_package(PythonInterp 3.6 REQUIRED)
+  set(Python_FIND_VIRTUALENV FIRST)
+  find_package(Python REQUIRED COMPONENTS Development)
+  if(Python_VERSION VERSION_LESS 3.8)
+    message(FATAL_ERROR "Python version 3.8 or higher is required")
+  endif()
 
-    # Find NumPy headers
-    exec_program(${PYTHON_EXECUTABLE}
-        ARGS "-c \"import numpy;import os; print(numpy.get_include()+os.sep+'numpy')\""
-        OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
-        RETURN_VALUE NUMPY_NOT_FOUND
-        )
-    if(NUMPY_NOT_FOUND)
-        message(FATAL_ERROR "NumPy headers not found")
-    endif()
+  find_package(Python COMPONENTS NumPy REQUIRED)
 
-    # Find Python headers
-    exec_program(${PYTHON_EXECUTABLE}
-        ARGS "-c \"import sysconfig; print(sysconfig.get_paths()['include'])\""
-        OUTPUT_VARIABLE PYTHON_INCLUDE_DIRS
-        RETURN_VALUE PYTHON_INCLUDE_DIRS_NOT_FOUND
-        )
-    if(PYTHON_INCLUDE_DIRS_NOT_FOUND)
-        message(FATAL_ERROR "Python headers not found")
-    endif()
+  # some systems need this extra include dir
+  find_path(_numpy_incdir
+  NAMES ndarrayobject.h
+  HINTS ${Python_NumPy_INCLUDE_DIRS}
+  PATH_SUFFIXES numpy
+  )
+  if(_numpy_incdir)
+    list(APPEND Python_NumPy_INCLUDE_DIRS ${_numpy_incdir})
+  endif()
 
-    # This goes after, since it uses PythonInterp as a hint
-    if(WIN32)
-        find_package(PythonLibs 3.6 REQUIRED)
-    endif()
+  message(STATUS "Python version: ${Python_VERSION}
+Numpy Include: ${Python_NumPy_INCLUDE_DIRS}
+Python Include: ${Python_INCLUDE_DIRS}
+  ")
 
-    if(STAGGERED_MACOS)
-        find_package(PythonLibs 3.6 REQUIRED)
-    endif()
+  set(PYTHON_C_EXTENSION_SRCS FDTDStaggered3D_with_relaxation_python.c)
 
-    
-    set(PYTHON_C_EXTENSION_SRCS
-          "FDTDStaggered3D_with_relaxation_python.c"
-      )
+  add_library(python_c_extension SHARED ${PYTHON_C_EXTENSION_SRCS})
 
+  set_target_properties(python_c_extension
+      PROPERTIES
+          PREFIX ""
+          OUTPUT_NAME "${STAGGERED_PYTHON_C_MODULE_NAME}"
+          LINKER_LANGUAGE C
+  )
+  if(MSVC)
+    set_property(TARGET python_c_extension PROPERTY SUFFIX ".pyd")
+  endif()
 
-    add_library(python_c_extension SHARED ${PYTHON_C_EXTENSION_SRCS})
+  target_include_directories(python_c_extension PUBLIC
+  ${Python_INCLUDE_DIRS}
+  ${Python_NumPy_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src/headers
+  )
 
-    set_target_properties(
-        python_c_extension
-        PROPERTIES
-            PREFIX ""
-            OUTPUT_NAME ${STAGGERED_PYTHON_C_MODULE_NAME}
-            LINKER_LANGUAGE C
-    )
-
-    if(WIN32)
-        set_target_properties(
-            python_c_extension
-            PROPERTIES
-            SUFFIX ".pyd"
-        )
-    endif()
-
-    
-
-    target_include_directories(python_c_extension PUBLIC
-    ${PYTHON_INCLUDE_DIRS}
-    ${NUMPY_INCLUDE_DIR}
-    ${PROJECT_SOURCE_DIR}/src/headers
-    )
-
-
-    target_link_libraries(python_c_extension)
-
-    # On Windows, it is required to link to the Python libraries
-
-    target_link_libraries(python_c_extension ${PYTHON_LIBRARIES})
-
-    
-    if(APPLE)
-      set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-    endif(APPLE)
+  # On Windows, it is required to link to the Python libraries
+  target_link_libraries(python_c_extension PRIVATE
+  ${Python_LIBRARIES}
+  $<$<BOOL:${OpenMP_C_FOUND}>:OpenMP::OpenMP_C>
+  )
 
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,10 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 
+  get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+  if("Swift" IN_LIST languages)
+    add_subdirectory(Metal)
+  endif()
 endif()
 
 


### PR DESCRIPTION
* fix OpenMP finding and linking
* fix Python numpy find and link
* correct compiler options, especially for clang
* remove unused/incorrect syntax
* set build type using CMake's general built-in flags